### PR TITLE
Add task scheduler airflow to infra

### DIFF
--- a/apps/airflow/app.yaml
+++ b/apps/airflow/app.yaml
@@ -33,10 +33,7 @@ spec:
                   - name: TS_USERSPACE
                     value: "false"
                 securityContext:
-                  capabilities:
-                     add:
-                      - NET_ADMIN
-
+                  privileged: true
         statsd:
           enabled: false
         createUserJob:

--- a/apps/airflow/app.yaml
+++ b/apps/airflow/app.yaml
@@ -18,6 +18,20 @@ spec:
         images:
           migrationsWaitTimeout: 600
           useDefaultImageForMigration: true
+        webserver:
+            extraContainers:
+              - name: tailscale-sidecar
+                image: ghcr.io/tailscale/tailscale:latest
+                env:
+                  - name: TS_KUBE_SECRET
+                    value: tailscale-auth
+                  - name: TS_AUTHKEY
+                    valueFrom:
+                      secretKeyRef:
+                        name: tailscale-auth
+                        key: TS_AUTHKEY
+                  - name: TS_USERSPACE
+                    value: "false"
         statsd:
           enabled: false
         createUserJob:

--- a/apps/airflow/app.yaml
+++ b/apps/airflow/app.yaml
@@ -7,13 +7,25 @@ spec:
   destination:
     namespace: airflow
     server: https://kubernetes.default.svc
-  project: default
+  project: data
   source:
     repoURL: http://airflow.apache.org/
     targetRevision: 1.15.0
     chart: airflow
     helm:
       releaseName: airflow
+      valuesObject:
+        images:
+          migrationsWaitTimeout: 600
+          useDefaultImageForMigration: true
+        statsd:
+          enabled: false
+        createUserJob:
+          useHelmHooks: false
+          applyCustomEnv: false
+        migrateDatabaseJob:
+          useHelmHooks: false
+          applyCustomEnv: false
   syncPolicy:
     automated:
       prune: true

--- a/apps/airflow/app.yaml
+++ b/apps/airflow/app.yaml
@@ -19,21 +19,11 @@ spec:
           migrationsWaitTimeout: 600
           useDefaultImageForMigration: true
         webserver:
-            extraContainers:
-              - name: tailscale-sidecar
-                image: ghcr.io/tailscale/tailscale:latest
-                env:
-                  - name: TS_KUBE_SECRET
-                    value: tailscale-auth
-                  - name: TS_AUTHKEY
-                    valueFrom:
-                      secretKeyRef:
-                        name: tailscale-auth
-                        key: TS_AUTHKEY
-                  - name: TS_USERSPACE
-                    value: "false"
-                securityContext:
-                  privileged: true
+          service:
+            annotations:
+              tailscale.com/expose: "true"
+          webserverConfig: |
+              CSRF_ENABLED = false
         statsd:
           enabled: false
         createUserJob:

--- a/apps/airflow/app.yaml
+++ b/apps/airflow/app.yaml
@@ -32,6 +32,11 @@ spec:
                         key: TS_AUTHKEY
                   - name: TS_USERSPACE
                     value: "false"
+                securityContext:
+                  capabilities:
+                     add:
+                      - NET_ADMIN
+
         statsd:
           enabled: false
         createUserJob:

--- a/apps/airflow/app.yaml
+++ b/apps/airflow/app.yaml
@@ -38,6 +38,8 @@ spec:
           useHelmHooks: false
           applyCustomEnv: false
         migrateDatabaseJob:
+          jobAnnotations:
+            "argocd.argoproj.io/hook": Sync
           useHelmHooks: false
           applyCustomEnv: false
   syncPolicy:

--- a/apps/airflow/app.yaml
+++ b/apps/airflow/app.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: airflow
+  namespace: argocd
+spec:
+  destination:
+    namespace: airflow
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: http://airflow.apache.org/
+    targetRevision: 1.15.0
+    chart: airflow
+    helm:
+      releaseName: airflow
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/apps/superset/app.yaml
+++ b/apps/superset/app.yaml
@@ -7,7 +7,7 @@ spec:
   destination:
     namespace: superset
     server: https://kubernetes.default.svc
-  project: default
+  project: data
   source:
     repoURL: http://apache.github.io/superset/
     targetRevision: 0.13.4
@@ -21,6 +21,9 @@ spec:
             "psycopg2-binary>=2.9.10" pillow \
             &&\
           if [ ! -f ~/bootstrap ]; then echo "Running Superset with uid {{ .Values.runAsUser }}" > ~/bootstrap; fi
+        service:
+          type: ClusterIP
+          port: 80
         supersetNode:
           extraContainers:
             - name: tailscale-sidecar

--- a/projects/data.yaml
+++ b/projects/data.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: data
+  namespace: argocd # Use the namespace where ArgoCD is installed
+spec:
+  description: Data-related applications managed by ArgoCD
+  sourceRepos:
+    - '*' # Allows access to all repositories; adjust as needed for specific repos
+  destinations:
+    - namespace: '*' # Allows deployment to any namespace; adjust as needed
+      server: '*'     # Allows deployment to any cluster; adjust as needed
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  namespaceResourceBlacklist:
+    - group: ''
+      kind: ResourceQuota
+    - group: ''
+      kind: LimitRange
+  syncWindows: [] # Define sync windows if needed
+  roles: []        # Define roles for RBAC if needed
+


### PR DESCRIPTION
# Introduction

In this PR, we add task scheduler airflow for regularly rerun jobs. This will be used to fetch weather data eg. temp and rainfall from data[dot]gov[dot]sg. 

minor change:
Also include additional project: data to keep apps together

> TODO: still need to figure out how to sync the dagbag. will do so in separate issue+PR