### PR TITLE
Add git-sync to fetch dags

### DIFF
--- a/apps/airflow/app.yaml
+++ b/apps/airflow/app.yaml
@@ -36,6 +36,13 @@ spec:
             "argocd.argoproj.io/hook": Sync
           useHelmHooks: false
           applyCustomEnv: false
+        dags:
+          gitSync:
+            enabled: true
+            repo: https://github.com/NEA-EHI-Informatics/airflow
+            branch: production
+            credentialsSecret: git-credentials
+            subPath: dags
   syncPolicy:
     automated:
       prune: true

--- a/apps/airflow/secrets.yaml
+++ b/apps/airflow/secrets.yaml
@@ -18,3 +18,13 @@ metadata:
   name: webserver-secret-key
 stringData:
   webserver-secret-key: <REDACTED>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: git-credentials
+data:
+  GITSYNC_USERNAME: <REDACTED>
+  GITSYNC_PASSWORD: <REDACTED>
+  GIT_SYNC_USERNAME: <REDACTED>
+  GIT_SYNC_PASSWORD: <REDACTED>


### PR DESCRIPTION
# Introduction

Include `git-sync` sidecar to fetch DAGs approved in git-ops flow from `production` branch of the airflow repository