### PR TITLE
Fix kaitai struct parser

### DIFF
--- a/monitoring/lanximonitor/README.md
+++ b/monitoring/lanximonitor/README.md
@@ -38,3 +38,7 @@ Copy the generated binary `lanxi-monitor` to the following directory `/home/ubun
 1. Get the default by running `GET` against `http://<URL>/rest/rec/channels/input/all/transducers`. See example config: [setup.json](./setup.json)
 
 You'll need to get the `serialNumber` of the **attached** tranducers and edit the default values. 
+
+# References
+
+For more information regarding the LAN-XI module's REST API please refer to this [PDF guide](https://www.bksv.com/-/media/literature/Manuals/be1872.ashx)

--- a/monitoring/lanximonitor/lanxi.go
+++ b/monitoring/lanximonitor/lanxi.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"lanxi-monitor/openapi"
@@ -11,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -414,9 +416,17 @@ func (c *LANXIClient) ProcessDataStream(ctx context.Context, cfg *config) error 
 		msg := openapi.NewOpenapiMessage()
 		err = msg.Read(kaitai.NewStream(brs), nil, nil)
 		if err != nil {
-			if err == io.EOF {
-				logger.Info("Stream connection closed")
-				return err
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				logger.Info("Stream connection closed, reconnecting...")
+				conn.Close()
+				conn, err = net.Dial("tcp", fmt.Sprintf("%s:%d", cfg.lanxiHost, c.port))
+				// TODO(wesley): add reconnection logic with backoff
+				continue
+			} else if strings.Contains(err.Error(), "exceeds maximum allowed") {
+				logger.Error("Invalid message size, resetting connection")
+				conn.Close()
+				// Reconnect logic
+				continue
 			}
 			logger.Error("Failed to parse message", "error", err)
 			continue

--- a/monitoring/lanximonitor/openapi/openapi_message.go
+++ b/monitoring/lanximonitor/openapi/openapi_message.go
@@ -674,12 +674,16 @@ func (this *OpenapiMessage_Value) CalcValue() (v int, err error) {
 		return this.calcValue, nil
 	}
 
-	this.calcValue = int(
-		int32(this.Value1) + // value1 (u1 -> uint32)
-			(int32(this.Value2) << 8) + // value2 (u1 -> uint32, shifted left by 8 bits)
-			(int32(this.Value3) << 16), // value3 (s1 -> int32, shifted left by 16 bits)
-	)
+	// Cast components to proper signed types first
+	v1 := int32(this.Value1)       // u1 → uint8 → int32
+	v2 := int32(this.Value2) << 8  // u1 → uint8 → int32
+	v3 := int32(this.Value3) << 16 // s1 → int8 → int32
 
+	combined := v1 + v2 + v3
+	if combined > 0x007FFFFF { // If exceeds positive 24-bit max
+		combined -= 0x01000000 // Adjust for 2's complement
+	}
+	this.calcValue = int(combined)
 	this._f_calcValue = true
 	return this.calcValue, nil
 }


### PR DESCRIPTION
# Introduction

Due to incorrect parsing of the message header, we are allocating too big of a byte slice, beyond that available on the raspberry pi. 

In this fix, we will check the signed nature and adjust this 